### PR TITLE
Syntax updates

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,7 @@
     "native-modules": true,
     "dependencies": {
         "elm-lang/core": "2.0.0 <= v < 3.0.0",
-        "evancz/elm-effects": "1.0.0 <= v < 2.0.0",
+        "evancz/elm-effects": "2.0.0 <= v < 3.0.0",
         "evancz/elm-html": "4.0.1 <= v < 5.0.0",
         "evancz/elm-http": "1.0.0 <= v < 2.0.0",
         "evancz/elm-markdown": "1.1.5 <= v < 2.0.0",

--- a/frontend/public/blog/announce/0.12.1.elm
+++ b/frontend/public/blog/announce/0.12.1.elm
@@ -47,7 +47,7 @@ structures and clever optimizations behind immutable arrays very clearly.
 Balanced Trees][rrbt] for Elm.
 
  [infoq]: http://www.infoq.com/presentations/julia-vectors-maps-sets
- [rrbt]: http://infoscience.epfl.ch/record/169879/files/RMTrees.pdf%E2%80%8E
+ [rrbt]: http://infoscience.epfl.ch/record/169879/files/RMTrees.pdf
 
 #### High-level Overview
 

--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -93,7 +93,7 @@ The keywords `if` `then` `else` are used to separate the conditional and the two
 
 It is important to note that Elm does not have a notion of &ldquo;truthiness&rdquo; as in many dynamic languages, where numbers and strings and lists all can be used as boolean values. If we try it out, Elm will tell us that we need to work with a real boolean value.
 
-Now lets make a function that tells us if a number is over 9000.
+Now let's make a function that tells us if a number is over 9000.
 
 ```elm
 > over9000 powerLevel = \\

--- a/src/guide/chapters/core-language.md
+++ b/src/guide/chapters/core-language.md
@@ -165,7 +165,7 @@ Tuples are another useful data structure. A tuple can hold a fixed number of val
 (True, "name accepted!")
 ```
 
-This can be quite handy, but when things start becoming more complicated, it is often best to use records instead tuples.
+This can be quite handy, but when things start becoming more complicated, it is often best to use records instead of tuples.
 
 
 ## Records

--- a/src/guide/chapters/model-the-problem.md
+++ b/src/guide/chapters/model-the-problem.md
@@ -3,7 +3,7 @@
 
 Many languages have trouble expressing data with weird shapes in a reliable way. You often find yourself doing weird tricks with boolean flags or strings, or giving in and letting the language force you into a model that is slightly off. Either way you end up with code that is hard to maintain and refactor!
 
-This section goes through the parts of Elm that let you work with crazy data in a way is reliable and easy to refactor. We will start with a foundation of &ldquo;contracts&rdquo; and then use them with progressively crazier and crazier data.
+This section goes through the parts of Elm that let you work with crazy data in a way that is reliable and easy to refactor. We will start with a foundation of &ldquo;contracts&rdquo; and then use them with progressively crazier and crazier data.
 
 
 ## Contracts
@@ -47,7 +47,7 @@ isLong book =
   book.pages > 400
 ```
 
-In the `averageNameLength` example, we are requiring that our input is a list of strings. If someone tries to pass in a list of integers or books, the `String.length` function would break, so this contract rules that out. We also say the `averageNameLength` function is definitely going to return a `Float` so if we use its result somewhere else, we have a 100% guarantee that its a floating point number.
+In the `averageNameLength` example, we are requiring that our input is a list of strings. If someone tries to pass in a list of integers or books, the `String.length` function would break, so this contract rules that out. We also say the `averageNameLength` function is definitely going to return a `Float` so if we use its result somewhere else, we have a 100% guarantee that it's a floating point number.
 
 The `isLong` example is doing exactly the same thing. It requires a record with a field name `pages` that holds integers. Any record will do, with however many other fields you want, but we definitely need the `pages` field!
 

--- a/src/guide/chapters/reactivity.md
+++ b/src/guide/chapters/reactivity.md
@@ -249,7 +249,7 @@ These are both exactly the same, but in the second one, it is a bit more
 explicit that we are waiting for a `time` and then printing it out.
 
 The [`andThen`][andThen] function is extremely important when using tasks
-because it let’s us build complex chains. We will be seeing more of it in
+because it lets us build complex chains. We will be seeing more of it in
 future examples!
 
 

--- a/src/guide/chapters/reactivity.md
+++ b/src/guide/chapters/reactivity.md
@@ -106,9 +106,8 @@ elm-package install evancz/elm-http -y
 elm-package install evancz/elm-markdown -y
 ```
 
-This exposes the `TaskTutorial` module which has [a friendly
-values][task-tutorial] that will help build a foundation for working with
-tasks.
+This exposes the `TaskTutorial` module which has [a few values][task-tutorial]
+that will help build a foundation for working with tasks.
 
 [task-tutorial]: http://package.elm-lang.org/packages/evancz/task-tutorial/latest/TaskTutorial
 

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -209,8 +209,10 @@ of a known type carried with it.
 ```elm
 -- a simple enumeration
 type ConnectionStatus = Connecting | Connected | Disconnected | CouldNotConnect
+
 -- Any Node will have two other values, one of which is recursive
 type ListOfInts = Empty | Node Int ListOfInts
+
 -- a "tree of a", where "a" can be any type
 type Tree a = Leaf | Node a (Tree a) (Tree a)
 ```

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -245,6 +245,13 @@ There is a special function for creating tuples:
 
 You can use as many commas as you want.
 
+The empty tuple or *unit* is sometimes used as a placeholder value. It is
+the only value of its type.
+
+```elm
+() : ()
+```
+
 ### Records
 
 A tuple holds values in order; a record holds values by key.

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -88,7 +88,8 @@ You can also compare Elm's literals to [those in JavaScript](/docs/from-javascri
 
 ### Lists
 
-The list is Elm's main data structure. Here are four equal lists:
+The list is Elm's main data structure. Every element in a list must be of the same
+type. Here are four equal lists:
 
 ```elm
 [1..4]

--- a/src/pages/docs/syntax.elm
+++ b/src/pages/docs/syntax.elm
@@ -232,6 +232,10 @@ dot' =
 
 Historical note: this is borrowed from F#, inspired by Unix pipes.
 
+Relatedly, [`(<<)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#<<)
+and [`(>>)`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#>>)
+are function composition operators.
+
 
 ### Let Expressions
 


### PR DESCRIPTION
- Merges in latest changes upstream
- Manually fixes a merge conflict (Janis added >> and <<, which I had in the revision already)
- More improvements to the syntax page
  - Space out union type examples
  - Mention `()`

Going to leave this open for a bit in case I think of something else to add.
